### PR TITLE
Cleaner-looking newlines for the attribute list

### DIFF
--- a/templates/schema_attributes.html
+++ b/templates/schema_attributes.html
@@ -2,6 +2,9 @@ $def with (attribs)
 $var title: Item Attributes
 $var description: List of all attributes for a given title, including those that are unused or hidden.
 
+$def add_newline(last):
+  $if not last: <font color=grey>\n</font>
+
 <div id="header">
   <h2>All item attributes</h2>
   <h5>Click on an attribute name to see the items it is attached to.</h5>
@@ -26,7 +29,8 @@ $var description: List of all attributes for a given title, including those that
           <td>
             $if desc:
               $ mmstr = "<{0}>".format(valtype)
-              $desc.replace("\n", "\\n").replace("%s1", mmstr)
+              $ desclines = desc.replace("%s1", mmstr).split('\n')
+              $for line in desclines:$line$:add_newline(loop.last)
           </td>
 	  <td>
 	    $if attr.hidden: Yes


### PR DESCRIPTION
Previews on the 3 different background types:
<img width="552" alt="screen shot 2016-10-10 at 12 46 09 am" src="https://cloud.githubusercontent.com/assets/2764675/19229524/1ac63ca2-8e83-11e6-9e7a-f4aa416596a3.png">
<img width="536" alt="screen shot 2016-10-10 at 12 46 13 am" src="https://cloud.githubusercontent.com/assets/2764675/19229523/1ac5b124-8e83-11e6-8083-63d350ab91af.png">
<img width="572" alt="screen shot 2016-10-10 at 12 46 18 am" src="https://cloud.githubusercontent.com/assets/2764675/19229525/1ac98182-8e83-11e6-9c7b-df00ce509390.png">
