### PR TITLE
Fix int value formatting for debug text, add paintkitweapon color

### DIFF
--- a/optf2/markup.py
+++ b/optf2/markup.py
@@ -274,7 +274,12 @@ def generate_attribute_list(app, item, showlinks = False):
         atype = attr.get("type", "neutral")
         aid = attr["id"]
         name = attr["name"]
-        val = "{0:.3g}".format(attr["val_raw"])
+        val = attr["val_raw"]
+        if (float(val).is_integer()):
+            val = "{0:d}".format(int(val))
+        else:
+            val = "{0:.3g}".format(val)
+
         debug = int(web.input(debug=0).debug)
 
         if not desc and not debug:

--- a/static/theme/common.css
+++ b/static/theme/common.css
@@ -69,6 +69,7 @@ a:visited { text-decoration: none; }
 .prefix-rarity1, .prefix-genuine { color: #4d7455; }
 .prefix-strange { color: #cf6a32; }
 .prefix-collectors { color: #aa0000; }
+.prefix-paintkitweapon { color: #fafafa; }
 .prefix-giftwrapped { color: #cf2700; }
 .prefix-frozen { color: #4682B4; }
 .prefix-exalted { color: #CCCCCC; }
@@ -107,6 +108,7 @@ a:visited { text-decoration: none; }
 .cell-rarity1, .cell-genuine { border-color: #4d7455; }
 .cell-strange { border-color: #cf6a32; }
 .cell-collectors { border-color: #aa0000; }
+.cell-paintkitweapon { border-color: #fafafa; }
 .cell-frozen { border-color: #4682B4; }
 .cell-exalted { border-color: #CCCCCC; }
 .cell-corrupted { border-color: #A52A2A; }


### PR DESCRIPTION
Woop.

This ends up catching round float values too, but that shouldn't matter (e.g. 64.0 turns into 64).
